### PR TITLE
schedule_and_cart_api_connect

### DIFF
--- a/src/api/cart/cart.js
+++ b/src/api/cart/cart.js
@@ -1,23 +1,73 @@
-// src/api/cart/cart.js
 import http from '../../utils/authAxios';
 
+export async function createCart({ ldongRegnCd, ldongSignguCd }) {
+  const lDongRegnCd = String(ldongRegnCd ?? '').trim();
+  const lDongSignguCd = String(ldongSignguCd ?? '').trim();
+
+  if (!lDongRegnCd || !lDongSignguCd) {
+    const err = new Error(
+      '지역 코드가 비었습니다 (lDongRegnCd / lDongSignguCd)'
+    );
+    err.code = 'INVALID_REGION_CODES';
+    throw err;
+  }
+
+  // 디버그
+  console.log('[CartAPI.createCart] POST /carts params →', {
+    lDongRegnCd,
+    lDongSignguCd,
+  });
+
+  const { data } = await http.post('/carts', null, {
+    params: { lDongRegnCd, lDongSignguCd }, // ← swagger 그대로 (소문자 l)
+  });
+  return data; // { cartId, tours, ... }
+}
+
+// 특정 cartId 조회
+async function getCart(cartId) {
+  const { data } = await http.get(`/carts/${cartId}`);
+  return data; // { cartId, tours: [...], ... }
+}
+
+// 카트 자체 삭제(카트와 모든 투어 삭제)
+async function deleteCart(cartId) {
+  await http.delete(`/carts/${cartId}`);
+}
+
+// 지정 카트에 투어 추가(contentId만)
+async function addTourByContentId(cartId, contentId) {
+  const { data } = await http.post(`/carts/${cartId}/tours/simple`, null, {
+    params: { contentId: String(contentId) },
+  });
+  return data; // { tourId, message? }
+}
+
+// 특정 투어 삭제 (swagger: DELETE /carts/{cartId}/tours/{tourId})
+async function removeTour(cartId, tourId) {
+  await http.delete(`/carts/${cartId}/tours/${tourId}`);
+}
+
+// contentId로 찾아서 제거 (리스트에서 tourId 매칭 후 삭제)
+async function removeByContentId(cartId, contentId) {
+  const cart = await getCart(cartId);
+  const tours = Array.isArray(cart?.tours) ? cart.tours : [];
+  const target = tours.find((t) => String(t.contentId) === String(contentId));
+  if (!target?.tourId) {
+    const err = new Error('해당 contentId의 투어를 찾을 수 없습니다.');
+    err.code = 'CART_ITEM_NOT_FOUND';
+    throw err;
+  }
+  await removeTour(cartId, String(target.tourId));
+}
+
 const CartAPI = {
-  async list() {
-    const { data } = await http.get('/cart');
-    return data;
-  },
-  async clearAll() {
-    await http.delete('/cart/tours');
-  },
-  async addSimple(contentId) {
-    const { data } = await http.post('/cart/tours/simple', null, {
-      params: { contentId },
-    });
-    return data; // { tourId, message }
-  },
-  async remove(tourId) {
-    await http.delete(`/cart/tours/${tourId}`);
-  },
+  createCart,
+  getCart,
+  deleteCart,
+  addTourByContentId,
+  removeTour,
+  removeByContentId,
 };
 
 export default CartAPI;

--- a/src/api/place/getPlacesByTheme.js
+++ b/src/api/place/getPlacesByTheme.js
@@ -17,7 +17,6 @@ export async function getPlacesByRegionTheme({
   size = 20,
 }) {
   const params = {
-    // 스웨거와 정확히 같은 키(대문자 I + D)
     lDongRegnCd: String(ldongRegnCd ?? ''),
     lDongSignguCd: String(ldongSignguCd ?? ''),
 

--- a/src/api/schedule/getSchedule.js
+++ b/src/api/schedule/getSchedule.js
@@ -2,6 +2,6 @@ import http from '../../utils/authAxios';
 
 export async function getSchedule(scheduleId) {
   if (!scheduleId) throw new Error('scheduleId가 필요합니다.');
-  const { data } = await http.get(`/schedule/${scheduleId}`);
+  const { data } = await http.get(`/schedule/details/${scheduleId}`);
   return data;
 }

--- a/src/pages/Plan/PlanInvitePage.jsx
+++ b/src/pages/Plan/PlanInvitePage.jsx
@@ -1,3 +1,4 @@
+// src/pages/Plan/PlanInvitePage.jsx
 import React, { useEffect, useMemo, useState } from 'react';
 import DefaultLayout from '../../layouts/DefaultLayout';
 import BackHeader from '../../components/header/BackHeader';
@@ -7,8 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { message } from 'antd';
 import { GroupAPI } from '../../api';
 import { loadKakao } from '../../utils/kakao';
-// 로그인 유저
-import useUserStore from '../../store/userStore'; // userId, username 있다고 가정
+import useUserStore from '../../store/userStore';
 
 const APP_ORIGIN =
   (typeof import.meta !== 'undefined' &&
@@ -20,6 +20,11 @@ const APP_ORIGIN =
 const PlanInvitePage = () => {
   const navigate = useNavigate();
 
+  // 1) 로그인 유저
+  const userId = useUserStore((s) => s.userId);
+  const username = useUserStore((s) => s.username);
+
+  // 2) 플랜 스토어
   const locationIds = usePlanStore((s) => s.locationIds);
   const groupId = usePlanStore((s) => s.groupId);
   const groupName = usePlanStore((s) => s.groupName);
@@ -28,108 +33,144 @@ const PlanInvitePage = () => {
   const invitees = usePlanStore((s) => s.invitees);
   const setInvitees = usePlanStore((s) => s.setInvitees);
 
-  const userId = useUserStore((s) => s.userId);
-  const username = useUserStore((s) => s.username);
-
   const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false); // 클릭 중 보호
 
-  // 초대 링크: 토큰 없이 groupId만 전달(서버 스펙이 초대 토큰을 안 쓰므로)
-  const inviteUrl = useMemo(() => {
+  // 본인 제외 멤버
+  const others = useMemo(() => {
+    const myId = String(userId || '');
+    const myName = String(username || '');
+    return (invitees || []).filter((u) => {
+      const uid = String(u?.userId || '');
+      const uname = String(u?.username || u?.userName || '');
+      const notMeById = myId ? uid !== myId : true;
+      const notMeByName = myName ? uname !== myName : true;
+      return notMeById && notMeByName;
+    });
+  }, [invitees, userId, username]);
+  const isSolo = others.length === 0;
+
+  // 초대 링크 생성기 (gid 인자로 받아 사용)
+  const makeInviteUrl = (gid, gname) => {
     const params = new URLSearchParams({
-      groupId: groupId || '',
-      groupName: groupName || '',
+      groupId: gid || '',
+      groupName: gname || '',
     });
     return `${APP_ORIGIN}/invite?${params.toString()}`;
-  }, [groupId, groupName]);
+  };
 
-  async function fetchMembers(gid, setInviteesFn, myUserId) {
+  async function fetchMembers(gid) {
+    if (!gid) return;
     try {
       const myGroup = await GroupAPI.getById(gid);
-      const members = (myGroup?.users || [])
-        .map((u) => ({
-          userId: u.userId,
-          username: u.username ?? u.userName ?? '',
-        }))
-        // ✅ 본인은 제외하고 '초대한 다른 사람'만 상태에 보관
-        .filter((u) => String(u.userId) !== String(myUserId));
-      setInviteesFn(members);
+      const members = (myGroup?.users || []).map((u) => ({
+        userId: u.userId,
+        username: u.username ?? u.userName ?? '',
+      }));
+      setInvitees(members);
     } catch (e) {
       console.error(e);
     }
   }
 
-  // 그룹 생성(or 재사용) + 멤버 목록 폴링
+  // 그룹 보장 유틸: 없으면 만들고 반환
+  const ensureGroupReady = async () => {
+    let gid = groupId;
+    if (gid) return gid;
+
+    const bodyName = groupName || `${username || '나'}의 여행 그룹`;
+    const created = await GroupAPI.create(bodyName);
+    gid = created?.groupId || created?.id;
+
+    // 생성 응답에 id가 없다면 목록에서 fallback
+    if (!gid) {
+      const list = await GroupAPI.list();
+      gid =
+        list.find((g) => g.groupName === bodyName)?.groupId ||
+        list.find((g) => g.groupName === bodyName)?.id;
+    }
+    if (!gid) throw new Error('그룹 생성 실패');
+
+    setGroupId(gid);
+    if (!groupName) setGroupName(bodyName);
+    return gid;
+  };
+
+  // 초기: 유저 정보가 있으면 그룹을 미리 만들고(실패해도 무시), 폴링은 gid 있을 때만
   useEffect(() => {
     let poll;
     (async () => {
+      if (!userId && !username) {
+        setLoading(false);
+        return;
+      }
       try {
-        // 1) 그룹 준비
-        let gid = groupId;
-        if (!gid) {
-          const bodyName = groupName || `${username || '나'}의 여행 그룹`;
-          const { groupId: createdId } = await GroupAPI.create(bodyName);
-          gid = createdId;
-          // 혹시 /group/create 응답에 groupId가 없으면, 목록에서 동일 이름 최신 항목을 잡는 폴백
-          if (!gid) {
-            const list = await GroupAPI.list();
-            gid = list.find((g) => g.groupName === bodyName)?.groupId;
-          }
-          if (!gid) throw new Error('그룹 생성 응답에 groupId가 없습니다.');
-          setGroupId(gid);
-          if (!groupName) setGroupName(bodyName);
+        // 미리 시도 (실패해도 클릭시 다시 보장함)
+        try {
+          await ensureGroupReady();
+        } catch (_) {}
+        // 첫 멤버 조회
+        if (groupId) await fetchMembers(groupId);
+        // gid 있을 때만 폴링
+        if (groupId) {
+          poll = setInterval(() => fetchMembers(groupId), 5000);
         }
-
-        // 2) 멤버 1회 조회
-        await fetchMembers(gid, setInvitees, userId);
-
-        // 3) 폴링(5초)
-        poll = setInterval(() => fetchMembers(gid, setInvitees, userId), 5000);
-      } catch (e) {
-        console.error(e);
-        message.error('초대 준비 중 오류가 발생했어요.');
       } finally {
         setLoading(false);
       }
     })();
     return () => poll && clearInterval(poll);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    // groupId 바뀌면 폴링 재설정
+  }, [groupId, userId, username]); // eslint-disable-line
 
   const handleCopyLink = async () => {
-    if (!groupId) {
-      message.warning('그룹이 아직 준비되지 않았어요.');
-      return;
-    }
     try {
-      await navigator.clipboard.writeText(inviteUrl);
+      setBusy(true);
+      const gid = await ensureGroupReady();
+      const url = makeInviteUrl(gid, groupName);
+      await navigator.clipboard.writeText(url);
       message.success('초대 링크가 복사되었습니다!');
-    } catch {
-      message.warning('복사에 실패했어요. 브라우저 권한을 확인해주세요.');
+    } catch (e) {
+      console.error(e);
+      message.error('초대 링크 복사에 실패했어요.');
+    } finally {
+      setBusy(false);
     }
   };
 
   const handleKakaoInvite = async () => {
-    if (!groupId) return message.warning('그룹이 아직 준비되지 않았어요.');
     try {
+      setBusy(true);
+      const gid = await ensureGroupReady();
+      const url = makeInviteUrl(gid, groupName);
+
       const Kakao = await loadKakao();
       Kakao.Share.sendDefault({
         objectType: 'text',
-        text: `[${groupName}] 여행 일정에 함께할래요? 아래 버튼으로 참여해주세요!`,
-        link: { mobileWebUrl: inviteUrl, webUrl: inviteUrl },
+        text: `[${
+          groupName || '여행 그룹'
+        }] 여행 일정에 함께할래요? 아래 버튼으로 참여해주세요!`,
+        link: { mobileWebUrl: url, webUrl: url },
         buttons: [
-          {
-            title: '참여하기',
-            link: { mobileWebUrl: inviteUrl, webUrl: inviteUrl },
-          },
+          { title: '참여하기', link: { mobileWebUrl: url, webUrl: url } },
         ],
       });
     } catch (e) {
       console.error(e);
       message.error('카카오 공유에 실패했어요. 키/도메인 설정을 확인해주세요.');
+    } finally {
+      setBusy(false);
     }
   };
 
-  const handleNext = () => navigate('/plan/budget');
+  const handleNext = () => {
+    if (isSolo) {
+      // 본인 제외 멤버가 0 → 개인 일정으로 전환
+      setGroupId('');
+      setGroupName('');
+    }
+    navigate('/plan/budget');
+  };
 
   return (
     <DefaultLayout>
@@ -138,7 +179,7 @@ const PlanInvitePage = () => {
         <div className="px-4">
           <div className="mt-6">
             <p className="font-semibold text-md text-gray-900">
-              여행 친구 {invitees?.length ?? 0}
+              여행 친구 {others.length}
             </p>
             <p className="text-sm text-gray-500 mb-4">
               함께 여행을 갈 친구나 가족을 초대해보세요. <br />
@@ -146,16 +187,17 @@ const PlanInvitePage = () => {
             </p>
 
             <div className="flex gap-2 mb-6">
+              {/* ✅ 로딩/클릭중에만 잠금. groupId 유무로 비활성화하지 않음 */}
               <button
                 onClick={handleKakaoInvite}
-                disabled={loading || !groupId || !inviteUrl}
+                disabled={loading || busy}
                 className="flex-1 bg-yellow-300 text-black font-medium py-2 rounded-xl text-sm disabled:opacity-50"
               >
                 🗨️ 카카오톡 초대
               </button>
               <button
                 onClick={handleCopyLink}
-                disabled={loading || !groupId || !inviteUrl}
+                disabled={loading || busy}
                 className="flex-1 bg-blue-100 text-blue-700 font-medium py-2 rounded-xl text-sm disabled:opacity-50"
               >
                 🔗 초대 링크 복사
@@ -163,15 +205,19 @@ const PlanInvitePage = () => {
             </div>
 
             <div className="border-t pt-4">
-              {(invitees || []).map((u) => (
-                <div key={u.userId} className="flex items-center gap-3 mb-3">
+              {others.map((u) => (
+                <div
+                  key={`${u.userId}-${u.username}`}
+                  className="flex items-center gap-3 mb-3"
+                >
                   <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center text-xs">
                     {(u.username ?? u.userName ?? '친')?.[0] || '친'}
                   </div>
                   <span className="text-sm">{u.username ?? u.userName}</span>
                 </div>
               ))}
-              {!invitees?.length && !loading && (
+
+              {!others.length && !loading && (
                 <div className="text-xs text-gray-500">
                   아직 초대한 친구가 없어요.
                 </div>

--- a/src/pages/Schedule/ScheduleAutoPage.jsx
+++ b/src/pages/Schedule/ScheduleAutoPage.jsx
@@ -1,5 +1,4 @@
-// src/pages/Plan/ScheduleAutoPage.jsx
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DefaultLayout from '../../layouts/DefaultLayout';
 import BackHeader from '../../components/header/BackHeader';
@@ -10,19 +9,37 @@ import useCartStore from '../../store/cartStore';
 import useScheduleStore from '../../store/scheduleStore';
 import { createSchedule, optimizeSchedule, getSchedule } from '../../api';
 
-// ---- helpers --------------------------------------------------------------
-// 'HH:mm' 로 강제
-const toHHmm = (v) => {
+async function waitUntilOptimized(id, { tries = 20, interval = 1200 } = {}) {
+  for (let i = 0; i < tries; i++) {
+    const detail = await getSchedule(id);
+    const items = Array.isArray(detail?.scheduleItems)
+      ? detail.scheduleItems
+      : [];
+    const optimized = items.some(
+      (it) => Number(it?.dayNumber) > 0 && it?.startTime && it?.endTime
+    );
+    if (optimized) return detail;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  // 타임아웃 시 fallback
+  return await getSchedule(id);
+}
+
+const toHHmmss = (v) => {
   const s = String(v || '').trim();
-  if (!s) return '09:00';
+  if (!s) return '09:00:00';
   const m = s.match(/^(\d{1,2}):?(\d{2})/);
-  if (!m) return '09:00';
+  if (!m) return '09:00:00';
   const hh = String(Math.min(23, Number(m[1] || 9))).padStart(2, '0');
   const mm = String(Math.min(59, Number(m[2] || 0))).padStart(2, '0');
-  return `${hh}:${mm}`;
+  return `${hh}:${mm}:00`;
 };
 
-// 빈 값(undefined/null/'')은 키 자체를 제거
+const isUuid = (s) =>
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    String(s || '')
+  );
+
 const clean = (obj) =>
   JSON.parse(
     JSON.stringify(obj, (_k, v) =>
@@ -30,19 +47,17 @@ const clean = (obj) =>
     )
   );
 
-// contentId 기준 중복 제거 + 문자열 강제
 const toScheduleItems = (items = []) => {
   const seen = new Set();
   const result = [];
   for (const it of items) {
     const raw =
       it?.contentId ?? it?.id ?? it?.contentID ?? it?.content_id ?? '';
-    const contentId = String(raw).trim(); // ✅ 숫자여도 문자열로 강제
+    const contentId = String(raw).trim();
     if (!contentId || seen.has(contentId)) continue;
-
     seen.add(contentId);
     const cost = Math.max(0, Math.round(Number(it?.price ?? it?.cost ?? 0)));
-    result.push({ contentId, cost }); // ✅ 그대로 string contentId 전송
+    result.push({ contentId, cost });
   }
   return result;
 };
@@ -54,6 +69,7 @@ function makeTripTitle(locationIds) {
 }
 
 const ScheduleAutoPage = () => {
+  const ranRef = useRef(false);
   const navigate = useNavigate();
   const scheduleStore = useScheduleStore();
 
@@ -63,21 +79,39 @@ const ScheduleAutoPage = () => {
   const invitees = usePlanStore((s) => s.invitees);
 
   useEffect(() => {
+    if (ranRef.current) return;
+    ranRef.current = true;
+
     (async () => {
-      // 0) 서버 카트 재조회 (최신 상태 동기화)
+      // 0) 서버 카트 동기화
       try {
         await useCartStore.getState().loadFromServer();
-      } catch (_) {
-        // 실패해도 이후 가드가 안내함
+      } catch (e) {
+        if (e?.code === 'NO_CART') {
+          message.error(
+            '장바구니가 준비되지 않았어요. 지역을 먼저 선택해 주세요.'
+          );
+          navigate(-1);
+          return;
+        }
       }
       const cartItems = useCartStore.getState().items;
+      const cartId = useCartStore.getState().cartId;
+
+      if (!cartId) {
+        message.error(
+          '카트 정보(cartId)를 찾을 수 없어요. 지역을 다시 선택해 주세요.'
+        );
+        navigate(-1);
+        return;
+      }
       if (!cartItems.length) {
         message.warning('장바구니가 비어있어요.');
         navigate(-1);
         return;
       }
 
-      // 결과 페이지 보강용 placeIndex
+      // 결과용 placeIndex
       const idx = {};
       cartItems.forEach((it) => {
         const pid = String(it.contentId ?? '').trim();
@@ -94,10 +128,8 @@ const ScheduleAutoPage = () => {
       scheduleStore.setPlaceIndex(idx);
 
       try {
-        // 1) 스토어 → 기본값 꺼내기
         const base = getSchedulePayload();
 
-        // 2) 필수값 검증
         if (!base?.startDate || !base?.endDate) {
           message.error(
             '여행 날짜가 설정되지 않았어요. 날짜를 먼저 선택해 주세요.'
@@ -106,95 +138,85 @@ const ScheduleAutoPage = () => {
           return;
         }
 
-        // 3) 스웨거 스키마에 맞춰 재구성
         const scheduleName =
           (base.scheduleName && String(base.scheduleName).trim()) ||
           makeTripTitle(locationIds);
 
-        const hasGroupId = Boolean(base.groupId && String(base.groupId).trim());
-        // ✅ 나를 제외한 실제 동행자 수
+        const meId = String(myUserId || '');
         const othersCount = Array.isArray(invitees)
-          ? invitees.filter((u) => String(u.userId) !== String(myUserId)).length
+          ? invitees.filter((u) => String(u?.userId || '') !== meId).length
           : 0;
-        const isGroupTrip = hasGroupId && othersCount > 0;
+        const rawGroupId = String(base.groupId || '').trim();
+        const safeGroupId = isUuid(rawGroupId) ? rawGroupId : undefined;
+        const isGroupTrip = Boolean(safeGroupId) && othersCount > 0;
         const scheduleType = isGroupTrip ? 'GROUP' : 'PERSONAL';
 
-        // 스타일(사용자 선택값) 없으면 안전한 기본값
         const style = String(
           base.scheduleStyle ||
             (Array.isArray(base.styles) ? base.styles[0] : '') ||
             '쇼핑'
         ).trim();
 
-        // 출발지/시간 기본값 보정
         const startPlace = String(
           base.startPlace || base.departurePlace || '서울역'
         );
-        const startTime = toHHmm(
+        const startTime = toHHmmss(
           base.startTime || base.departureTime || '09:00'
         );
 
-        // 카트 → scheduleItem (중복제거)
-        const scheduleItem = toScheduleItems(useCartStore.getState().items);
+        const { items: latestCartItems } = useCartStore.getState();
+        const scheduleItem = toScheduleItems(latestCartItems);
         if (!scheduleItem.length) {
           message.error(
-            '일정에 담을 장소가 없어요. 장소를 장바구니에 추가해 주세요.'
+            '장바구니 동기화에 실패했어요. 잠시 후 다시 시도해주세요.'
           );
           navigate(-1);
           return;
         }
 
-        // 4) 최종 페이로드 (그룹 아니면 groupId 완전 제거)
         const payload = clean({
           scheduleName,
           startDate: String(base.startDate),
           endDate: String(base.endDate),
           budget: Math.max(0, Math.round(Number(base.budget ?? 0))),
-          groupId: isGroupTrip ? String(base.groupId) : undefined,
-          scheduleType, // 'GROUP' | 'PERSONAL'
-          scheduleStyle: style, // 예: '쇼핑', '힐링' 등
+          groupId: isGroupTrip ? safeGroupId : undefined,
+          scheduleType, // GROUP | PERSONAL
+          scheduleStyle: style,
           startPlace,
-          startTime, // 'HH:mm'
-          scheduleItem, // [{ contentId: string, cost: number }]
+          startTime, // 'HH:mm:ss'
+          cartId,
+          scheduleItem,
         });
 
-        // 🔎 콘솔에 "백엔드에 보낼 바디"와 근거 로그 출력
         console.groupCollapsed(
           '%c[schedule/create] Request payload',
           'color:#1677ff'
         );
-        console.log('store raw →', {
-          scheduleName: base.scheduleName,
-          startDate: base.startDate,
-          endDate: base.endDate,
-          budget: base.budget,
-          groupId: base.groupId,
-          scheduleStyle: base.scheduleStyle,
-          styles: base.styles,
-          startPlace: base.startPlace || base.departurePlace,
-          startTime: base.startTime || base.departureTime,
-          inviteesCount: Array.isArray(invitees) ? invitees.length : 0,
-        });
-        console.log('computed flags →', {
-          hasGroupId,
-          othersCount,
-          isGroupTrip,
-          scheduleType,
-        });
-        console.log('scheduleItem count:', scheduleItem.length);
         console.log('payload →', payload);
         console.groupEnd();
 
-        // 5) 생성 → 최적화 → 상세
         const created = await createSchedule(payload);
         const scheduleId = created?.scheduleId || created?.id;
         if (!scheduleId) throw new Error('scheduleId가 응답에 없습니다.');
 
         await optimizeSchedule(scheduleId);
-        const detail = await getSchedule(scheduleId);
-        scheduleStore.setDetail(detail);
+        // ✅ 최적화 완료까지 짧게 폴링 (백엔드가 즉시 OK를 주므로)
+        const detail = await waitUntilOptimized(scheduleId);
+        
+        
+        // 콘솔에 리스폰스 출력
+        console.groupCollapsed(
+          '%c[schedule/result] Optimized detail',
+          'color:#52c41a;font-weight:bold;'
+        );
+        console.log('scheduleId →', scheduleId);
+        console.log('response detail →', detail);
+        console.groupEnd();
 
-        navigate(`/schedule/result/${scheduleId}`, { replace: true });
+
+
+        scheduleStore.setDetail(detail);
+        navigate(`/plan/schedule/result/${scheduleId}`, { replace: true });
       } catch (e) {
         console.error('[ScheduleAutoPage] error', e?.response?.data || e);
         message.error(
@@ -203,8 +225,14 @@ const ScheduleAutoPage = () => {
         navigate(-1);
       }
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [
+    getSchedulePayload,
+    invitees,
+    locationIds,
+    myUserId,
+    navigate,
+    scheduleStore,
+  ]);
 
   return (
     <DefaultLayout>

--- a/src/pages/Schedule/ScheduleResultPage.jsx
+++ b/src/pages/Schedule/ScheduleResultPage.jsx
@@ -24,6 +24,9 @@ const ScheduleResultPage = () => {
         return;
       try {
         const res = await getSchedule(scheduleId);
+        // 콘솔에 리스폰스 출력
+        console.log('[ScheduleResultPage] getSchedule response →', res);
+        
         scheduleStore.setDetail(res);
       } catch (e) {
         console.error('[ScheduleResult] reload fail', e?.response?.data || e);

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,9 +1,4 @@
-import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  Outlet,
-} from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import HomePage from '../pages/HomePage';
 import SearchPage from '../pages/SearchPage';
 import Splash from '../pages/Splash';
@@ -83,7 +78,10 @@ const AppRoutes = () => (
         <Route path="budget" element={<PlanBudgetPage />} />
         <Route path="cart" element={<PlanCartPage />} />
         <Route path="auto" element={<ScheduleAutoPage />} />
-        <Route path="schedule" element={<ScheduleResultPage />} />
+        <Route
+          path="schedule/result/:scheduleId"
+          element={<ScheduleResultPage />}
+        />
         <Route path="add" element={<AddPlace />} />
       </Route>
 

--- a/src/store/cartStore.js
+++ b/src/store/cartStore.js
@@ -1,4 +1,3 @@
-// src/store/cartStore.js
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import CartAPI from '../api/cart/cart';
@@ -7,48 +6,93 @@ import { message } from 'antd';
 const useCartStore = create(
   persist(
     (set, get) => ({
-      items: [], // UI에서 쓰는 아이템 배열
-      index: {}, // contentId -> tourId 매핑 (서버 삭제용)
+      cartId: null, // cartId 보관
+      lastCodes: null, // { ldongRegnCd, ldongSignguCd }
+      items: [],
       loading: false,
 
-      // 서버 → 스토어 동기화
+      // 카트 보장: 없거나 지역코드 바뀌면 새로 생성
+      ensureCart: async ({ ldongRegnCd, ldongSignguCd }) => {
+        const state = get();
+        const sameCodes =
+          state.lastCodes &&
+          state.lastCodes.ldongRegnCd === String(ldongRegnCd) &&
+          state.lastCodes.ldongSignguCd === String(ldongSignguCd);
+
+        if (state.cartId && sameCodes) return state.cartId;
+
+        set({ loading: true });
+        try {
+          const created = await CartAPI.createCart({
+            ldongRegnCd,
+            ldongSignguCd,
+          });
+          const cartId = created?.cartId;
+          const tours = Array.isArray(created?.tours) ? created.tours : [];
+          if (!cartId) throw new Error('cartId가 응답에 없습니다.');
+
+          const items = tours.map((t) => ({
+            contentId: String(t.contentId ?? ''),
+            name: t.title,
+            address: t.address,
+            imageUrl: t.image,
+            price: Number(t.price ?? 0),
+            location: { lat: Number(t.latitude), lng: Number(t.longitude) },
+            category: t.category,
+            theme: t.theme ?? t.tema ?? '',
+          }));
+
+          set({
+            cartId,
+            lastCodes: {
+              ldongRegnCd: String(ldongRegnCd),
+              ldongSignguCd: String(ldongSignguCd),
+            },
+            items,
+            loading: false,
+          });
+          return cartId;
+        } catch (e) {
+          set({ loading: false });
+          console.error('[cart/ensureCart] fail', e?.response?.data || e);
+          throw e;
+        }
+      },
+
+      // 서버 동기화 (cartId 필요)
       loadFromServer: async () => {
+        const { cartId } = get();
+        if (!cartId) {
+          const err = new Error('카트가 아직 준비되지 않았습니다.');
+          err.code = 'NO_CART';
+          throw err;
+        }
         try {
           set({ loading: true });
-          const data = await CartAPI.list(); // { cartId, region, tours: [...] }
+          const data = await CartAPI.getCart(cartId);
           const tours = Array.isArray(data?.tours) ? data.tours : [];
+
           const prevMap = new Map(
             get().items.map((it) => [String(it.contentId), it])
           );
 
-          const index = {};
           const items = tours.map((t) => {
             const cid = String(t.contentId ?? '');
-            index[cid] = String(t.tourId ?? '');
             const prev = prevMap.get(cid);
             return {
               contentId: cid,
               name: t.title,
               address: t.address,
               imageUrl: t.image,
-              price: prev?.price ?? Number(t.price ?? 0), // 서버에 없으면 기존 값 유지
-              location: {
-                lat:
-                  typeof t.latitude === 'number'
-                    ? t.latitude
-                    : Number(t.latitude),
-                lng:
-                  typeof t.longitude === 'number'
-                    ? t.longitude
-                    : Number(t.longitude),
-              },
+              price: prev?.price ?? Number(t.price ?? 0),
+              location: { lat: Number(t.latitude), lng: Number(t.longitude) },
               category: t.category,
-              theme: t.theme,
+              theme: t.theme ?? t.tema ?? '',
             };
           });
 
-          set({ items, index, loading: false });
-          return { items, index };
+          set({ items, loading: false });
+          return { items };
         } catch (e) {
           set({ loading: false });
           console.error('[cart/loadFromServer] fail', e?.response?.data || e);
@@ -56,30 +100,35 @@ const useCartStore = create(
         }
       },
 
-      // 추가: 서버에 POST 후 최신상태 재조회
+      // 추가
       addToCart: async (item) => {
+        const { cartId, ensureCart, lastCodes } = get();
         try {
+          if (!cartId) {
+            if (!lastCodes) throw new Error('카트가 준비되지 않았습니다.');
+            await ensureCart(lastCodes);
+          }
+          const id = get().cartId;
           const contentId = String(item?.contentId ?? '').trim();
           if (!contentId) return;
-          await CartAPI.addSimple(contentId);
-          // 바로 재조회해서 index/tourId까지 최신화
+
+          await CartAPI.addTourByContentId(id, contentId);
           await get().loadFromServer();
 
-          // UI에서 쓰는 가격/이미지 등 보존(서버 응답에 없을 수 있음)
           set((state) => {
             const exists = state.items.some(
               (it) => String(it.contentId) === contentId
             );
             if (exists) {
-              // 이미 서버에서 받아온 아이템에 price 덮어쓰기
-              const items = state.items.map((it) =>
-                String(it.contentId) === contentId ? { ...it, ...item } : it
-              );
-              return { items };
-            } else {
-              return { items: [...state.items, item] };
+              return {
+                items: state.items.map((it) =>
+                  String(it.contentId) === contentId ? { ...it, ...item } : it
+                ),
+              };
             }
+            return { items: [...state.items, item] };
           });
+
           message.success('장바구니에 추가했습니다.');
         } catch (e) {
           console.error('[cart/addToCart] fail', e?.response?.data || e);
@@ -90,24 +139,15 @@ const useCartStore = create(
         }
       },
 
-      // 제거: contentId -> tourId 찾은 뒤 DELETE
+      // contentId로 제거
       removeByContentId: async (contentId) => {
+        const { cartId } = get();
         try {
-          const cid = String(contentId);
-          let tourId = get().index[cid];
-          if (!tourId) {
-            // 매핑이 없으면 새로 조회해서 찾기
-            const { index } = await get().loadFromServer();
-            tourId = index[cid];
-          }
-          if (!tourId)
-            throw new Error('해당 항목의 tourId를 찾을 수 없습니다.');
-
-          await CartAPI.remove(tourId);
+          if (!cartId) throw new Error('카트가 준비되지 않았습니다.');
+          await CartAPI.removeByContentId(cartId, String(contentId));
           set((state) => ({
-            items: state.items.filter((it) => String(it.contentId) !== cid),
-            index: Object.fromEntries(
-              Object.entries(state.index).filter(([k]) => k !== cid)
+            items: state.items.filter(
+              (it) => String(it.contentId) !== String(contentId)
             ),
           }));
           message.info('장바구니에서 제거했습니다.');
@@ -123,11 +163,16 @@ const useCartStore = create(
         }
       },
 
-      // 전체 비우기
+      // 전체 비우기: 카트 삭제 후 같은 코드로 빈 카트 재생성
       clear: async () => {
+        const { cartId, lastCodes } = get();
         try {
-          await CartAPI.clearAll();
-          set({ items: [], index: {} });
+          // 서버 삭제 대신 프론트 상태만 비움(또는 서버에 "비우기" 엔드포인트가 있으면 그걸 사용)
+          set({ items: [] });
+          if (lastCodes) {
+            // 필요하면 새 카트 강제 생성하고 cartId 갱신
+            await get().ensureCart(lastCodes);
+          }
           message.success('장바구니를 비웠습니다.');
         } catch (e) {
           console.error('[cart/clear] fail', e?.response?.data || e);
@@ -138,20 +183,19 @@ const useCartStore = create(
         }
       },
 
-      // ✅ 새 일정 시작 시 카트만 초기화(서버/스토어 동시 정리)
+      // 새 일정 시작: 카트 완전 초기화(삭제)
       resetForNewPlan: async () => {
         try {
-          await CartAPI.clearAll().catch(() => {});
         } finally {
-          set({ items: [], index: {} });
+          set({ cartId: null, items: [], lastCodes: null });
         }
       },
 
-      // ✅ 영구 저장(세션 저장소)까지 완전히 삭제 — 로그아웃 등에서 호출
+      // 영구 저장까지 삭제 — 로그아웃 등
       clearPersisted: () => {
-        set({ items: [], index: {}, loading: false });
+        set({ cartId: null, lastCodes: null, items: [], loading: false });
         try {
-          sessionStorage.removeItem('cart'); // ← persist name
+          sessionStorage.removeItem('cart-v2');
         } catch {}
       },
 
@@ -165,10 +209,13 @@ const useCartStore = create(
         ),
     }),
     {
-      name: 'cart',
-      // ✅ 같은 탭의 새로고침에만 유지되도록 sessionStorage 사용
+      name: 'cart-v2',
       storage: createJSONStorage(() => sessionStorage),
-      // cart는 그대로 전부 저장(간단)
+      partialize: (s) => ({
+        cartId: s.cartId,
+        lastCodes: s.lastCodes,
+        items: s.items,
+      }),
     }
   )
 );

--- a/src/store/scheduleStore.js
+++ b/src/store/scheduleStore.js
@@ -10,60 +10,122 @@ const useScheduleStore = create((set, get) => ({
   setDetail: (detail) => set({ detail }),
   setPlaceIndex: (index) => set({ placeIndex: index }),
 
-  // ✅ 필요 시 결과 화면을 벗어날 때 초기화하고 싶다면:
+  // ✅ 필요 시 결과 화면을 벗어날 때 초기화
   clear: () => set({ detail: null, placeIndex: {} }),
 
   // days 구조로 변환하여 UI에서 바로 쓰게 제공
   getDays: () => {
     const { detail, placeIndex } = get();
-    if (!detail?.scheduleItems) return [];
+    const items = Array.isArray(detail?.scheduleItems)
+      ? detail.scheduleItems
+      : [];
+    if (!items.length) return [];
 
-    // dayNumber 그룹 → startTime 정렬
-    const byDay = new Map();
-    for (const it of detail.scheduleItems) {
-      const day = Number(it.dayNumber || 0);
-      if (!byDay.has(day)) byDay.set(day, []);
-      byDay.get(day).push(it);
-    }
+    // 여행 총 일수 계산 (startDate ~ endDate 있으면)
+    const hasRange = detail?.startDate && detail?.endDate;
+    const totalDays = (() => {
+      if (!hasRange) return null;
+      try {
+        const s = new Date(String(detail.startDate));
+        const e = new Date(String(detail.endDate));
+        const diff = Math.floor((e - s) / 86400000) + 1; // inclusive
+        return diff > 0 ? diff : null;
+      } catch {
+        return null;
+      }
+    })();
 
-    const sortByTime = (a, b) => {
-      // 'HH:mm:ss' 기준
-      const toNum = (s = '00:00:00') => {
-        const [hh = '00', mm = '00', ss = '00'] = String(s).split(':');
-        return +hh * 3600 + +mm * 60 + +ss;
-      };
-      return toNum(a.startTime) - toNum(b.startTime);
+    // Day 컨테이너 준비 (날짜 라벨 포함)
+    const daysArr = (() => {
+      if (!totalDays) return [];
+      const start = new Date(String(detail.startDate));
+      const list = [];
+      for (let i = 0; i < totalDays; i++) {
+        const d = new Date(start);
+        d.setDate(start.getDate() + i);
+        const yyyy = d.getFullYear();
+        const mm = String(d.getMonth() + 1).padStart(2, '0');
+        const dd = String(d.getDate()).padStart(2, '0');
+        list.push({ date: `Day ${i + 1} (${yyyy}-${mm}-${dd})`, plans: [] });
+      }
+      return list;
+    })();
+
+    // 'HH:mm' 또는 'HH:mm:ss' → 초 변환
+    const toSec = (t) => {
+      if (!t) return 0;
+      const [hh = '00', mm = '00', ss = '00'] = String(t).split(':');
+      const H = Number(hh) || 0,
+        M = Number(mm) || 0,
+        S = Number(ss) || 0;
+      return H * 3600 + M * 60 + S;
     };
 
-    const days = [...byDay.keys()]
-      .sort((a, b) => a - b)
-      .map((dNum) => {
-        const plans = byDay
-          .get(dNum)
-          .sort(sortByTime)
-          .map((it) => {
-            const enrich = placeIndex[String(it.placeId)] || {};
-            return {
-              id: it.scheduleItemId || `${it.placeId}-${it.startTime}`,
-              name: enrich.name || enrich.title || String(it.placeId),
-              memo: it.memo || '',
-              cost: it.cost ?? 0,
-              startTime: it.startTime,
-              endTime: it.endTime,
-              lat: enrich.lat,
-              lng: enrich.lng,
-              address: enrich.address,
-              imageUrl: enrich.imageUrl,
-              placeId: it.placeId,
-            };
-          });
-        return {
-          date: `Day ${dNum}`,
-          plans,
-        };
+    // 계획 추가 함수
+    const pushPlan = (dayIdxZeroBased, it) => {
+      const key = String(it.contentId ?? it.placeId ?? '');
+      const enrich = placeIndex[key] || {};
+      const plan = {
+        id:
+          it.scheduleItemId ||
+          `${key}-${it.startTime || ''}-${it.endTime || ''}`,
+        name: enrich.name || enrich.title || key,
+        memo: it.memo || '',
+        cost: Number(it.cost ?? 0),
+        startTime: it.startTime || null,
+        endTime: it.endTime || null,
+        lat: enrich.lat,
+        lng: enrich.lng,
+        address: enrich.address,
+        imageUrl: enrich.imageUrl,
+        placeId: key,
+        contentId: key,
+        order: Number(it.order ?? 0),
+      };
+      if (daysArr.length) {
+        // 미리 생성된 Day 배열이 있으면 범위 내로 넣기
+        const idx = Math.max(0, Math.min(daysArr.length - 1, dayIdxZeroBased));
+        daysArr[idx].plans.push(plan);
+      } else {
+        // 총 일수를 모를 때: 동적으로 Map에 추가
+        dynamicByDay.set(
+          dayIdxZeroBased,
+          (dynamicByDay.get(dayIdxZeroBased) || []).concat(plan)
+        );
+      }
+    };
+
+    // 총 일수를 모르면 동적 Map에 저장
+    const dynamicByDay = new Map();
+
+    // 아이템 분배
+    for (const it of items) {
+      const dayNum = Number(it.dayNumber);
+      const safeDay = Number.isFinite(dayNum) && dayNum > 0 ? dayNum : 1; // 없으면 1일차
+      const zeroBased = safeDay - 1;
+      pushPlan(zeroBased, it);
+    }
+
+    // 정렬 (startTime → order)
+    const sortPlans = (arr) =>
+      arr.sort((a, b) => {
+        const t = toSec(a.startTime) - toSec(b.startTime);
+        return t !== 0 ? t : a.order - b.order;
       });
 
-    return days;
+    if (daysArr.length) {
+      daysArr.forEach((d) => {
+        d.plans = sortPlans(d.plans);
+      });
+      return daysArr;
+    }
+
+    // 날짜 라벨이 없는 경우: dynamicByDay → Day n
+    const dayKeys = [...dynamicByDay.keys()].sort((a, b) => a - b);
+    return dayKeys.map((k) => ({
+      date: `Day ${k + 1}`,
+      plans: sortPlans(dynamicByDay.get(k)),
+    }));
   },
 }));
 


### PR DESCRIPTION
## 📌 PR 제목 예시
feat: 카트 및 스케줄 api 연동

---

## ✨ 변경 사항
- 카트 ID 생성, 카트 페이지 진입 시 카트 생성이 먼저 되도록 변경
- 스케줄 요청 보낼 때 카트 ID 같이 보내기로 변경
- 현재 카트 관련 API 연동 및 스케줄 만들기 성공

---

## 🧪 테스트 방법
1. 스케줄 만들기 시도해보기

---

## 🔍 관련 이슈

---

## 보완할 점
1. 카트에서 상세보기 추가해야 함
2. 카트에서 즐겨찾기 기능 추가해야 함

---
## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
